### PR TITLE
FM volume attenuation removed

### DIFF
--- a/Board/mist/fpgagen.qsf
+++ b/Board/mist/fpgagen.qsf
@@ -331,7 +331,6 @@ set_global_assignment -name ENABLE_BOOT_SEL_PIN OFF
 set_global_assignment -name CYCLONEIII_CONFIGURATION_SCHEME "PASSIVE SERIAL"
 set_global_assignment -name FORCE_CONFIGURATION_VCCIO ON
 set_global_assignment -name PROJECT_OUTPUT_DIRECTORY ../../syn/mist
-set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top
 set_global_assignment -name QIP_FILE ../../src/T80/T80.qip
 set_global_assignment -name VHDL_FILE ../../../Board/mist/MIST_Toplevel.vhd
 set_global_assignment -name SYSTEMVERILOG_FILE ../../Board/mist/rgb2ypbpr.sv
@@ -362,3 +361,4 @@ set_global_assignment -name VHDL_FILE ../../src/DualPortRAM.vhd
 set_global_assignment -name QIP_FILE ../../jt12/hdl/jt12.qip
 set_global_assignment -name SDC_FILE ../../Board/mist/constraints.sdc
 set_global_assignment -name CDF_FILE Chain1.cdf
+set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top

--- a/src/virtual_toplevel.vhd
+++ b/src/virtual_toplevel.vhd
@@ -772,8 +772,8 @@ FM_MUX_LEFT <= FM_LEFT when FM_ENABLE = '1' else "000000000000";
 FM_MUX_RIGHT <= FM_RIGHT when FM_ENABLE = '1' else "000000000000";
 PSG_MUX_SND <= PSG_SND when PSG_ENABLE = '1' else "000000";
 
-DAC_LDATA <= std_logic_vector(signed(FM_MUX_LEFT(11)&FM_MUX_LEFT&"000") + signed("0"&PSG_MUX_SND&"0000000"));
-DAC_RDATA <= std_logic_vector(signed(FM_MUX_RIGHT(11)&FM_MUX_RIGHT&"000") + signed("0"&PSG_MUX_SND&"0000000"));
+DAC_LDATA <= std_logic_vector(signed(FM_MUX_LEFT &"0000") + signed("0"&PSG_MUX_SND&"0000000"));
+DAC_RDATA <= std_logic_vector(signed(FM_MUX_RIGHT&"0000") + signed("0"&PSG_MUX_SND&"0000000"));
 
 -- #############################################################################
 -- #############################################################################


### PR DESCRIPTION
For some reason FM volume was attenuate on virtual top. I have removed that. This will give FM volume +6dB.

Note that FM gain was x2 in some JT12 releases, but from 0.51 onwards it will be x1 as I have identified at least one game where this clearly produces distortion. So in order to keep FM loud enough we need to remove attenuation from top level.