### PR TITLE
Time multiplexed output for JT12 (boosts gain) plus decreased volume for PSG

### DIFF
--- a/Board/mist/fpgagen.qsf
+++ b/Board/mist/fpgagen.qsf
@@ -331,7 +331,6 @@ set_global_assignment -name ENABLE_BOOT_SEL_PIN OFF
 set_global_assignment -name CYCLONEIII_CONFIGURATION_SCHEME "PASSIVE SERIAL"
 set_global_assignment -name FORCE_CONFIGURATION_VCCIO ON
 set_global_assignment -name PROJECT_OUTPUT_DIRECTORY ../../syn/mist
-set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top
 set_global_assignment -name QIP_FILE ../../src/T80/T80.qip
 set_global_assignment -name VHDL_FILE ../../../Board/mist/MIST_Toplevel.vhd
 set_global_assignment -name SYSTEMVERILOG_FILE ../../Board/mist/rgb2ypbpr.sv
@@ -362,3 +361,4 @@ set_global_assignment -name VHDL_FILE ../../src/DualPortRAM.vhd
 set_global_assignment -name QIP_FILE ../../jt12/hdl/jt12.qip
 set_global_assignment -name SDC_FILE ../../Board/mist/constraints.sdc
 set_global_assignment -name CDF_FILE Chain1.cdf
+set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top

--- a/src/virtual_toplevel.vhd
+++ b/src/virtual_toplevel.vhd
@@ -327,10 +327,10 @@ signal FM_DI			: std_logic_vector(7 downto 0);
 signal FM_DO			: std_logic_vector(7 downto 0);
 signal FM_CLKOUT		: std_logic;
 signal FM_SAMPLE		: std_logic;
-signal FM_LEFT			: std_logic_vector(11 downto 0);
-signal FM_RIGHT			: std_logic_vector(11 downto 0);
-signal FM_MUX_LEFT		: std_logic_vector(11 downto 0);
-signal FM_MUX_RIGHT		: std_logic_vector(11 downto 0);
+signal FM_LEFT			: std_logic_vector(8 downto 0);
+signal FM_RIGHT			: std_logic_vector(8 downto 0);
+signal FM_MUX_LEFT		: std_logic_vector(8 downto 0);
+signal FM_MUX_RIGHT		: std_logic_vector(8 downto 0);
 signal FM_ENABLE		: std_logic;
 
 -- PSG
@@ -760,20 +760,20 @@ port map(
 	din		=> FM_DI,
 	dout	=> FM_DO,
 
-	snd_left	=> FM_LEFT,
-	snd_right	=> FM_RIGHT
+	mux_left	=> FM_LEFT,
+	mux_right=> FM_RIGHT
 );
 
 -- Audio control
 PSG_ENABLE <= not SW(3);
 FM_ENABLE <= not SW(4);
 
-FM_MUX_LEFT <= FM_LEFT when FM_ENABLE = '1' else "000000000000";
-FM_MUX_RIGHT <= FM_RIGHT when FM_ENABLE = '1' else "000000000000";
+FM_MUX_LEFT  <= FM_LEFT  when FM_ENABLE = '1' else "000000000";
+FM_MUX_RIGHT <= FM_RIGHT when FM_ENABLE = '1' else "000000000";
 PSG_MUX_SND <= PSG_SND when PSG_ENABLE = '1' else "000000";
 
-DAC_LDATA <= std_logic_vector(signed(FM_MUX_LEFT &"0000") + signed("0"&PSG_MUX_SND&"0000000"));
-DAC_RDATA <= std_logic_vector(signed(FM_MUX_RIGHT&"0000") + signed("0"&PSG_MUX_SND&"0000000"));
+DAC_LDATA <= std_logic_vector(signed(FM_MUX_LEFT(8)  & FM_MUX_LEFT &"000000") + signed("00"&PSG_MUX_SND&"000000"));
+DAC_RDATA <= std_logic_vector(signed(FM_MUX_RIGHT(8) & FM_MUX_RIGHT&"000000") + signed("00"&PSG_MUX_SND&"000000"));
 
 -- #############################################################################
 -- #############################################################################

--- a/src/virtual_toplevel.vhd
+++ b/src/virtual_toplevel.vhd
@@ -772,8 +772,8 @@ FM_MUX_LEFT <= FM_LEFT when FM_ENABLE = '1' else "000000000000";
 FM_MUX_RIGHT <= FM_RIGHT when FM_ENABLE = '1' else "000000000000";
 PSG_MUX_SND <= PSG_SND when PSG_ENABLE = '1' else "000000";
 
-DAC_LDATA <= std_logic_vector(signed(FM_MUX_LEFT(11)&FM_MUX_LEFT&"000") + signed("0"&PSG_MUX_SND&"0000000"));
-DAC_RDATA <= std_logic_vector(signed(FM_MUX_RIGHT(11)&FM_MUX_RIGHT&"000") + signed("0"&PSG_MUX_SND&"0000000"));
+DAC_LDATA <= std_logic_vector(signed(FM_MUX_LEFT &"0000") + signed("0"&PSG_MUX_SND&"0000000"));
+DAC_RDATA <= std_logic_vector(signed(FM_MUX_RIGHT&"0000") + signed("0"&PSG_MUX_SND&"0000000"));
 
 -- #############################################################################
 -- #############################################################################


### PR DESCRIPTION
Real YM2612 had a time multiplexed channel output. This option is also present in JT12. The advantage of this option  is that when channels are mixed in the speaker, the result is that each YM2612 channel sounds with an attenuation of 1/6 over the total. In comparison, when the continuous time output is used, channel volume is attenuated by 1/8. Mux'ed output has a +2.5dB gain increase with respect to continuous time output.

Mux'ed output will affect a bit the "colour" of the sound, but that's exactly what real hardware did so this moves it closer.

I have also decreased the gain of the PSG so games sound better. Titles like Streets of Rage, which combines PSG and FM instruments, sound better now. 